### PR TITLE
fix: add link to api docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,5 @@
 [![Coverage Status](https://coveralls.io/repos/github/phpolar/phpolar-core/badge.svg?branch=main)](https://coveralls.io/github/phpolar/phpolar-core?branch=main) [![Latest Stable Version](http://poser.pugx.org/phpolar/phpolar-core/v)](https://packagist.org/packages/phpolar/phpolar-core) [![Total Downloads](http://poser.pugx.org/phpolar/phpolar-core/downloads)](https://packagist.org/packages/phpolar/phpolar-core) [![Latest Unstable Version](http://poser.pugx.org/phpolar/phpolar-core/v/unstable)](https://packagist.org/packages/phpolar/phpolar-core) [![License](http://poser.pugx.org/phpolar/phpolar-core/license)](https://packagist.org/packages/phpolar/phpolar-core) [![PHP Version Require](http://poser.pugx.org/phpolar/phpolar-core/require/php)](https://packagist.org/packages/phpolar/phpolar-core)
 
 ## Internal functionality and defaults
+
+## [API Documentation](https://phpolar.github.io/phpolar-core/)


### PR DESCRIPTION
Also using this commit to bump the version because of the enum member name changes.